### PR TITLE
Correct c extension

### DIFF
--- a/jupyter_c_kernel/kernel.py
+++ b/jupyter_c_kernel/kernel.py
@@ -72,7 +72,7 @@ class CKernel(Kernel):
     language_version = 'C11'
     language_info = {'name': 'c',
                      'mimetype': 'text/plain',
-                     'file_extension': 'c'}
+                     'file_extension': '.c'}
     banner = "C kernel.\n" \
              "Uses gcc, compiles in C11, and creates source code files and executables in temporary folder.\n"
 


### PR DESCRIPTION
The "c" extension missed a dot. this caused the following error:

```
root@82911d114c24:~# jupyter nbconvert Untitled.ipynb --to script
[NbConvertApp] Converting notebook Untitled.ipynb to script
Traceback (most recent call last):
  File "/opt/conda/bin/jupyter-nbconvert", line 6, in <module>
    sys.exit(main())
  File "/opt/conda/lib/python3.5/site-packages/jupyter_core/application.py", line 267, in launch_instance
    return super(JupyterApp, cls).launch_instance(argv=argv, **kwargs)
  File "/opt/conda/lib/python3.5/site-packages/traitlets/config/application.py", line 596, in launch_instance
    app.start()
  File "/opt/conda/lib/python3.5/site-packages/nbconvert/nbconvertapp.py", line 293, in start
    self.convert_notebooks()
  File "/opt/conda/lib/python3.5/site-packages/nbconvert/nbconvertapp.py", line 457, in convert_notebooks
    self.convert_single_notebook(notebook_filename)
  File "/opt/conda/lib/python3.5/site-packages/nbconvert/nbconvertapp.py", line 428, in convert_single_notebook
    output, resources = self.export_single_notebook(notebook_filename, resources, input_buffer=input_buffer)
  File "/opt/conda/lib/python3.5/site-packages/nbconvert/nbconvertapp.py", line 357, in export_single_notebook
    output, resources = self.exporter.from_filename(notebook_filename, resources=resources)
  File "/opt/conda/lib/python3.5/site-packages/nbconvert/exporters/exporter.py", line 165, in from_filename
    return self.from_file(f, resources=resources, **kw)
  File "/opt/conda/lib/python3.5/site-packages/nbconvert/exporters/exporter.py", line 183, in from_file
    return self.from_notebook_node(nbformat.read(file_stream, as_version=4), resources=resources, **kw)
  File "/opt/conda/lib/python3.5/site-packages/nbconvert/exporters/script.py", line 36, in from_notebook_node
    self.file_extension = langinfo.get('file_extension', '.txt')
  File "/opt/conda/lib/python3.5/site-packages/traitlets/traitlets.py", line 558, in __set__
    self.set(obj, value)
  File "/opt/conda/lib/python3.5/site-packages/traitlets/traitlets.py", line 532, in set
    new_value = self._validate(obj, value)
  File "/opt/conda/lib/python3.5/site-packages/traitlets/traitlets.py", line 564, in _validate
    value = self.validate(obj, value)
  File "/opt/conda/lib/python3.5/site-packages/nbconvert/exporters/exporter.py", line 40, in validate
    raise TraitError(msg.format(self.name, value))
traitlets.traitlets.TraitError: FileExtension trait 'file_extension' does not begin with a dot: 'c'
```

with the fix:

```
root@82911d114c24:~# jupyter nbconvert Untitled1.ipynb --to script
[NbConvertApp] Converting notebook Untitled1.ipynb to script
[NbConvertApp] Writing 65 bytes to Untitled1.c
```

I have not opened a separated issue, it was a very simple fix.