### PR TITLE
Fix #14: Add args magic to provide cli-args to user program

### DIFF
--- a/resources/master.c
+++ b/resources/master.c
@@ -25,5 +25,7 @@ int main(int argc, char **argv, char **envp)
         fprintf(stderr, "%s: %s\n", argv[0], error);
         return EXIT_FAILURE;
     }
-    return usermain(argc, argv, envp);
+
+    /* Call Users main, but make master.c invisible by removing first argument */
+    return usermain(argc-1, argv+1, envp);
 }


### PR DESCRIPTION
This PR fixes #14 by adding `//% args` as valid magic (case-insensitive) that can be used. It respects quotes as can be shown in code example below:

### code
```c
//% args: "one one" two "three \" three " four

#include <stdio.h>

int main( int argc, char *argv[] )  {
       
   for(int i=0; i < argc; i++)
   {
        printf("argv[%d]: >>%s<<\n", i, argv[i]);
   }
}
```

### stdout
```shell
argv[0]: >>/tmp/tmpq_vq_wdr.out<<
argv[1]: >>one one<<
argv[2]: >>two<<
argv[3]: >>three \" three <<
argv[4]: >>four<<
```