### PR TITLE
Update README typo and clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@
 
  * `docker pull brendanrius/jupyter-c-kernel`
  * `docker run -p 8888:8888 brendanrius/jupyter-c-kernel`
- * Copy the given URL containing the token, and browse to it.
+ * Copy the given URL containing the token, and browse to it. For instance:
+ 
+ ```
+ Copy/paste this URL into your browser when you connect for the first time,
+ to login with a token:
+    http://localhost:8888/?token=66750c80bd0788f6ba15760aadz53beb9a9fb4cf8ac15ce8
+ ```
 
 ## Manual installation
 
@@ -44,7 +50,7 @@ docker run -v $(pwd):/jupyter/jupyter_c_kernel/ -p 8888:8888 brendanrius/jupyter
 ```
 
 This clones the source, run the kernel, and binds the current folder (the one
-you just cloned) to eh corresponding folder in Docker.
+you just cloned) to the corresponding folder in Docker.
 Now, if you change the source, it will be reflected in [http://localhost:8888](http://localhost:8888)
 instantly. Do not forget to click "restart" the kernel on the page as it does
 not auto-restart.


### PR DESCRIPTION
fixes typo, and provides example for "URL containing the token".