### PR TITLE
Quick tweak for installtion in environments

### DIFF
--- a/jupyter_c_kernel/install_c_kernel
+++ b/jupyter_c_kernel/install_c_kernel
@@ -10,7 +10,7 @@ from IPython.utils.tempdir import TemporaryDirectory
 
 kernel_json = {
     "argv": [
-        "python3",
+        sys.executable,
         "-m",
         "jupyter_c_kernel",
         "-f",


### PR DESCRIPTION
A small tweak that will allow installing in a conda/mamba environments.

Eg in a jupyter notebook (as root):
```sh
mamba create -n c --yes pip ipykernel ipywidgets 
"${CONDA_DIR}/envs/c/bin/python" -m pip install --no-cache-dir install jupyter-c-kernel 
"${CONDA_DIR}/envs/c/bin/install_c_kernel" --user 
```